### PR TITLE
Add command to fire your editor from this tool.

### DIFF
--- a/conf/todotxt.cfg
+++ b/conf/todotxt.cfg
@@ -1,1 +1,4 @@
 todo_txt_path = ~/todo.txt
+
+# set editor for todotxt, defaults to $EDITOR.
+# todo_txt_editor = "vim"

--- a/lib/todotxt/cli.rb
+++ b/lib/todotxt/cli.rb
@@ -201,6 +201,11 @@ module Todotxt
     end
     map "rm" => :del
 
+    desc "edit", "Open todo.txt file in your default editor"
+    def edit
+      system "#{@editor} #{@txt_path}"
+    end
+
     #
     # File generation
     #
@@ -266,6 +271,7 @@ module Todotxt
 
       if txt
         @txt_path = File.expand_path(txt)
+        @editor   = cfg["todo_txt_editor"] || ENV["EDITOR"]
 
         unless File.exist? @txt_path
           puts "#{txt} doesn't exist yet. Would you like to generate a sample file?"


### PR DESCRIPTION
Uses $EDITOR by default. But editor can be configured
by setting an option in the todotxt.cfg called todo_txt_editor.
This is documented in that file.

Usable with `todotxt edit`
