### PR TITLE
Backwards compatibility checks for incompatible settings

### DIFF
--- a/features/backwards.feature
+++ b/features/backwards.feature
@@ -1,0 +1,28 @@
+Feature: Backwards compatibility
+
+  So that I can continue using todotxt on an older system
+  As a user
+  I want to run todotxt with an old config
+
+  Scenario: Running with an old config-file still works
+    Given an old config exists
+    And a todofile with the following items exists:
+       | todo                  | 
+       | Update my config file | 
+    When I run `todotxt`
+    Then it should pass with:
+      """
+      1. Update my config file
+      """
+
+  Scenario: Running with an old config-file and option --files fails
+    Given an old config exists
+    And a todofile with the following items exists:
+      | todo                  |
+      | Update my config file |
+    When I run `todotxt --file=done`
+    Then it should pass with exactly:
+      """
+      ERROR: You are using an old config, which has no support for mulitple files. Please update your configuration.
+
+      """

--- a/lib/todotxt/cli.rb
+++ b/lib/todotxt/cli.rb
@@ -21,6 +21,10 @@ module Todotxt
       @list   = nil
       unless ["help", "generate_config", "generate_txt"].include? ARGV[0]
         ask_and_create @config unless @config.file_exists?
+        if @config.deprecated? and options[:file]
+          error_and_exit "You are using an old config, which has no support for mulitple files. Please update your configuration."
+        end
+
         parse_conf
         ask_and_create @file unless @file.exists?
         @list = TodoList.new @file
@@ -347,24 +351,6 @@ module Todotxt
 
       # Determine the editor
       @editor = @config["editor"] || ENV["EDITOR"]
-    end
-
-    def validate
-      # Deprecation warning for old cfg file
-      # @TODO: remove after a few releases.
-      unless @cfg["todo_txt_path"].nil?
-        warn "DEPRECATION: you are using deprecated todo_txt_path setting in ~/.todotxt.cfg\n" \
-             "Please change this to use\n" \
-             "  [files]\n" \
-             "  todo  = ~/path/to/todo.txt\n"
-      end
-
-      # Determine if todo, the only required todo file is configured
-      unless @files.has_key? :todo
-        error_and_exit  "Couldn't find 'todo' path setting in ~/.todotxt.cfg.\n" \
-                        "  Please run the following to create a new configuration file:\n" \
-                        "  todotxt generate_config" \
-      end
     end
   end
 end

--- a/lib/todotxt/config.rb
+++ b/lib/todotxt/config.rb
@@ -44,6 +44,10 @@ module Todotxt
       File.join ENV["HOME"], ".todotxt.cfg"
     end
 
+    def deprecated?
+      params["files"].nil?
+    end
+
     private
     def validate
       if params["files"] && params["todo_txt_path"]

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -7,14 +7,32 @@ describe Todotxt::Config do
     @config_file = File.join ENV["HOME"], ".todotxt.cfg"
   end
 
-  it 'should have a "files"' do
-    cfg = Todotxt::Config.new "spec/fixtures/config_new.cfg"
-    cfg.files.keys.should include "todo"
+  context "valid config" do
+    before(:each) do
+      @cfg = Todotxt::Config.new "spec/fixtures/config_new.cfg"
+    end
+
+    it 'should have a "files"' do
+      @cfg.files.keys.should include "todo"
+    end
+
+    it 'should not be deprecated' do
+      @cfg.should_not be_deprecated
+    end
   end
 
-  it 'should place "todo_txt_path" under files' do
-    cfg = Todotxt::Config.new "spec/fixtures/config_old.cfg"
-    cfg.files.keys.should include "todo"
+  context "old style config" do
+    before(:each) do
+      @cfg = Todotxt::Config.new "spec/fixtures/config_old.cfg"
+    end
+
+    it 'should place "todo_txt_path" under files' do
+      @cfg.files.keys.should include "todo"
+    end
+
+    it 'should be deprecated' do
+      @cfg.should be_deprecated
+    end
   end
 
   it 'not allow both "files" and "todo_txt_path"' do


### PR DESCRIPTION
I found a bug in my previous commit. 

With the new config file, you can give a --file option to tell what file to work on. This fails when using the old style config, since that has no files. I now throw an error when someone tries to define a --file=foo but is using the old config.
I wrote some cucumber stories that explain the bugs and then fixed the bugs. 

The method that should test this, was not used. It is removed and refactored into the Config model, which is where it should have been. This new method on Config is specced with Rspec. Rspec has therefore been refactored a little, since I introduced some duplication otherwise.

I am now fixing some more issues with the --files which are slightly unrelated. This will be a separate pull-request.
