### PR TITLE
Use superclass defaults rather than relying on copied defaults.

### DIFF
--- a/lib/todotxt/config.rb
+++ b/lib/todotxt/config.rb
@@ -12,22 +12,23 @@ module Todotxt
     def initialize(options = {})
       @options = options
 
-      @config_file = options[:config_file] || Config.config_path
+      # Superclass will flunk if @config_file is set but not readable.
+      # But we need to be able to handle that situation. Hence we shadow
+      # the original @config_file and set it manually after initializing.
+      @try_config_file = options[:config_file] || Config.config_path
 
       if file_exists?
         super @config_file
         validate
       else
-        # Initialize mandatory values for `ParseConfig`
-        @params = {}
-        @groups = []
-        @splitRegex = '\s*=\s*'
-        @comments = [';']
+        super(nil)
       end
+
+      @config_file = @try_config_file
     end
 
     def file_exists?
-      File.exist? @config_file
+      File.exists? @config_file || @try_config_file
     end
 
     def files


### PR DESCRIPTION
This allows '#' as comment, as the superclass allows. It also means we
don't have to keep our hardcoded defaults in sync with the superclass.

The branch is called upgrade-2.x, because I was upgrading to recent ruby-versions, only to find out this had been done recently already and I was simply out of sync. Oops.

This commit is the only one that still makes sense after rebasing.