### PR TITLE
Feature/lighter numbers

### DIFF
--- a/features/step_definitions/list_steps.rb
+++ b/features/step_definitions/list_steps.rb
@@ -28,6 +28,7 @@ end
 Then /^it should output "([^"]*)" brightly in "([^"]*)"$/ do |string, color|
   assert_partial_output(string.color(color.to_sym).bright, all_output)
 end
+
 Then /^it should output "([^"]*)" in "([^"]*)"$/ do |string, color|
   assert_partial_output(string.color(color.to_sym), all_output)
 end

--- a/lib/todotxt/cli.rb
+++ b/lib/todotxt/cli.rb
@@ -309,7 +309,7 @@ module Todotxt
       end
 
       unless opts[:simple]
-        puts "TODO: #{@list.count} items".color(:black).bright
+        puts "TODO: #{@list.count} items".bright
       end
     end
 

--- a/lib/todotxt/clihelpers.rb
+++ b/lib/todotxt/clihelpers.rb
@@ -7,7 +7,7 @@ module Todotxt
       text = todo.to_s
 
       if todo.done
-        text = text.color(:black).bright
+        text = text.bright
       else
         text.gsub! PRIORITY_REGEX do |p|
           color = case p[1]
@@ -28,9 +28,9 @@ module Todotxt
         text.gsub! CONTEXT_REGEX, '\1'.color(:blue)
       end
 
-      ret = ''
+      ret = ""
 
-      ret << "#{line}. ".color(:black).bright
+      ret << "#{line}. ".bright
       ret << text.to_s
     end
 


### PR DESCRIPTION
Don't force "black", but use the main text color.

This adapts itself to dark or light terminal schemes. "black" becomes
unreadable on anything that is not a light background.

`black` is unreadable on dark schemes:

![before](https://user-images.githubusercontent.com/77059/68117850-c7dfec00-fefe-11e9-8589-f08f2ee565db.png)

But readable on light schemes:

![before_light](https://user-images.githubusercontent.com/77059/68117894-e0e89d00-fefe-11e9-9125-d454ab939433.png)


By removing the hardcoded black, the color adapts itself and becomes readable on both dark and light schemes:

![after_dark](https://user-images.githubusercontent.com/77059/68118033-4177da00-feff-11e9-81c5-60ce141e2d7b.png)
![after_light](https://user-images.githubusercontent.com/77059/68117924-fc53a800-fefe-11e9-968c-fcf5566562fc.png)


