### PR TITLE
Feature/fixup cucumber

### DIFF
--- a/features/backwards.feature
+++ b/features/backwards.feature
@@ -23,6 +23,6 @@ Feature: Backwards compatibility
     When I run `todotxt --file=done`
     Then it should pass with exactly:
       """
-      ERROR: You are using an old config, which has no support for mulitple files. Please update your configuration.
+      ERROR: You are using an old config, which has no support for multiple files. Please update your configuration.
 
       """

--- a/features/support/debugger.rb
+++ b/features/support/debugger.rb
@@ -1,1 +1,0 @@
-require "debugger"

--- a/lib/todotxt/todolist.rb
+++ b/lib/todotxt/todolist.rb
@@ -6,7 +6,7 @@ module Todotxt
   class TodoList
     include Enumerable
 
-    attr_reader :todos
+    attr_accessor :todos
 
     # @INK: refactor TodoList and TodoFile
     #   So that TodoFile contains all IO ad List is no longer dependent on file.


### PR DESCRIPTION
Cucumber broke due to the recently merged changes.

Seems like the CI and developer did not run cucumber or did not catch these. Fixed in this PR.

Cause could be that `rake`, the default task, only runs rspec and not all the tests. This may be confusing: cucumber has to be ran explicitly and manually.