### PR TITLE
Make due-date follow the todotxt convention: don't abuse the creation date

### DIFF
--- a/features/due.feature
+++ b/features/due.feature
@@ -15,35 +15,35 @@ Feature: Due
   Scenario: List due items
     Given the date is "2012-12-12"
     And a todofile with the following items exists:
-      | todo                                      |
-      | 2012-12-17 Install todotxt @cli +todotxt  |
-      | Read documentation +todotxt               |
-      | 2012-12-12 Buy GTD book @amazon +wishlist |
-      | 2012-12-19 Evaluate installation +todotxt |
+      | todo                                                     |
+      | 2012-11-17 Install todotxt due:2012-12-17 @cli +todotxt  |
+      | Read documentation +todotxt                              |
+      | Buy GTD book due:2012-12-12 @amazon +wishlist            |
+      | Evaluate installation due:2012-12-19 +todotxt            |
     When I run `todotxt due` interactively
     Then it should pass with exactly:
       """
       Due today (2012-12-12)
-      3. 2012-12-12 Buy GTD book @amazon +wishlist
+      3. Buy GTD book due:2012-12-12 @amazon +wishlist
 
       Past-due items
 
       Due 7 days in advance
-      1. 2012-12-17 Install todotxt @cli +todotxt
-      4. 2012-12-19 Evaluate installation +todotxt
+      1. 2012-11-17 Install todotxt due:2012-12-17 @cli +todotxt
+      4. Evaluate installation due:2012-12-19 +todotxt
 
       """
 
   Scenario: list overdue items
     Given the date is "2012-12-12"
     And a todofile with the following items exists:
-      | todo                                      |
-      | 2012-12-17 Install todotxt @cli +todotxt  |
-      | Read documentation +todotxt               |
-      | 2012-11-11 Buy GTD book @amazon +wishlist |
+      | todo                                                     |
+      | Install todotxt due:2012-12-17 @cli +todotxt             |
+      | Read documentation +todotxt                              |
+      | 2012-10-11 Buy GTD book due:2012-11-11 @amazon +wishlist |
     When I run `todotxt due` interactively
     Then it should pass with:
       """
       Past-due items
-      3. 2012-11-11 Buy GTD book @amazon +wishlist
+      3. 2012-10-11 Buy GTD book due:2012-11-11 @amazon +wishlist
       """

--- a/features/step_definitions/list_steps.rb
+++ b/features/step_definitions/list_steps.rb
@@ -1,3 +1,5 @@
+require "date"
+
 Then /^I should see all entries from the todofile with numbers$/ do
   step %{I should see all entries from the todofile named "todo.txt" with numbers}
 end

--- a/lib/todotxt/regex.rb
+++ b/lib/todotxt/regex.rb
@@ -2,6 +2,6 @@ module Todotxt
   PRIORITY_REGEX = /^\(([A-Z])\) /.freeze
   PROJECT_REGEX  = /(\+\w+)/.freeze
   CONTEXT_REGEX  = /(@\w+)/.freeze
-  DATE_REGEX     = /^(\([A-Z]\) )?(x )?((\d{4}-)(\d{1,2}-)(\d{1,2}))\s?/.freeze
+  DATE_REGEX     = /(\s+due:((\d{4}-)(\d{1,2}-)(\d{1,2})))/.freeze
   DONE_REGEX     = /^(\([A-Z]\) )?x /.freeze
 end

--- a/lib/todotxt/todo.rb
+++ b/lib/todotxt/todo.rb
@@ -28,7 +28,7 @@ module Todotxt
     # Get due date if set
     # @return [Date|Nil]
     def due
-      date = Chronic.parse(text.scan(DATE_REGEX).flatten[2])
+      date = Chronic.parse(text.scan(DATE_REGEX).flatten[1])
       date.nil? ? nil : date.to_date
     end
 

--- a/spec/todo_spec.rb
+++ b/spec/todo_spec.rb
@@ -25,14 +25,15 @@ describe Todotxt::Todo do
     expect(todo.done).to be_truthy
   end
 
-  it 'parses a due date' do
-    todo = Todotxt::Todo.new '(A) x 2012-12-12 an item +project1 +project2 @context1 @context2'
+  it 'parses a due: date' do
+    # prio state completion-date creation-date description ... key:value
+    todo = Todotxt::Todo.new '(A) x 2012-11-22 2011-11-12 an item due:2012-12-12 +project1 +project2 @context1 @context2'
     expect(todo.due).to eql(Chronic.parse('12 December 2012').to_date)
 
-    todo = Todotxt::Todo.new '2012-1-2 an item +project1 +project2 @context1 @context2'
+    todo = Todotxt::Todo.new 'item due:2012-1-2 +project1 +project2 @context1 @context2'
     expect(todo.due).to eql(Chronic.parse('2 January 2012').to_date)
 
-    todo = Todotxt::Todo.new '42 folders'
+    todo = Todotxt::Todo.new '2011-31-1 42 folders'
     expect(todo.due).to be_nil
   end
 

--- a/spec/todolist_spec.rb
+++ b/spec/todolist_spec.rb
@@ -48,15 +48,15 @@ describe Todotxt::TodoList do
     end
 
     it 'fetches items for a certain date' do
-      @list.add '2012-12-12 item'
+      @list.add 'item due:2012-12-12'
       date = DateTime.parse('2012-12-12')
       expect(@list.on_date(date).count).to eql 1
       expect(@list.on_date(date)).to match([@list.todos.last])
     end
 
     it 'fetchs items before a cereain date' do
-      @list.add '2012-11-11 item'
-      @list.add '2012-12-12 item'
+      @list.add 'item due:2012-11-11'
+      @list.add 'item due:2012-12-12'
       date = DateTime.parse('2012-12-12')
       expect(@list.before_date(date).count).to eql 1
     end


### PR DESCRIPTION
Currently, todotxt gem is incompatible with todo.txt as it uses the
space for 'creation date' to store a 'due date'.
https://github.com/todotxt/todo.txt#todotxt-format-rules

This patch changes that to use the key:value format as place
to hold due: dates.
https://github.com/todotxt/todo.txt#additional-file-format-definitions

This makes it compatible with e.g. simpletask app and gnome-todo.